### PR TITLE
Add support for new attribute syntax using `@`

### DIFF
--- a/syntaxes/wgsl.tmLanguage.json
+++ b/syntaxes/wgsl.tmLanguage.json
@@ -9,6 +9,9 @@
             "include": "#keywords"
         },
         {
+            "include": "#attributes"
+        },
+        {
             "include": "#functions"
         },
         {
@@ -32,6 +35,23 @@
             "comment": "single line comment",
             "name": "comment.line.double-slash.wgsl",
             "match": "\\s*//.*"
+        },
+        "attributes": {
+            "patterns": [
+                {
+                    "comment": "attribute declaration",
+                    "name": "meta.attribute.wgsl",
+                    "match": "(@)([A-Za-z_]+)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.operator.attribute.at"
+                        },
+                        "2": {
+                            "name": "entity.name.attribute.wgsl"
+                        }
+                        }
+                }
+            ]
         },
         "functions": {
             "patterns": [
@@ -62,6 +82,9 @@
                         },
                         {
                             "include": "#keywords"
+                        },
+                        {
+                            "include": "#attributes"
                         },
                         {
                             "include": "#function_calls"
@@ -108,6 +131,9 @@
                         },
                         {
                             "include": "#keywords"
+                        },
+                        {
+                            "include": "#attributes"
                         },
                         {
                             "include": "#function_calls"

--- a/syntaxes/wgsl.tmLanguage.yml
+++ b/syntaxes/wgsl.tmLanguage.yml
@@ -3,6 +3,7 @@ scopeName: source.wgsl
 patterns:
   - include: "#line_comments"
   - include: "#keywords"
+  - include: "#attributes"
   - include: "#functions"
   - include: "#function_calls"
   - include: "#constants"
@@ -14,6 +15,17 @@ repository:
     comment: single line comment
     name: comment.line.double-slash.wgsl
     match: \s*//.*
+
+  attributes:
+    patterns:
+      - comment: attribute declaration
+        name: meta.attribute.wgsl
+        match: (@)([A-Za-z_]+)
+        captures:
+          1:
+            name: keyword.operator.attribute.at
+          2:
+            name: entity.name.attribute.wgsl
 
   functions:
     patterns:
@@ -34,6 +46,7 @@ repository:
         patterns:
           - include: "#line_comments"
           - include: "#keywords"
+          - include: "#attributes"
           - include: "#function_calls"
           - include: "#constants"
           - include: "#types"
@@ -57,6 +70,7 @@ repository:
         patterns:
           - include: "#line_comments"
           - include: "#keywords"
+          - include: "#attributes"
           - include: "#function_calls"
           - include: "#constants"
           - include: "#types"

--- a/test.wgsl
+++ b/test.wgsl
@@ -1,33 +1,32 @@
-[[block]]
 struct ViewUniform {
     transform: mat4x4<f32>;
     size: vec2<f32>;
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<uniform> view_uniform: ViewUniform;
 
 struct Vertex {
-    [[location(0)]] position: vec2<f32>;
+    @location(0) position: vec2<f32>;
 };
 
 struct QuadInstance{
-    [[location(1)]] position: vec2<f32>;
-    [[location(2)]] size: vec2<f32>;
-    [[location(3)]] color: vec4<f32>;
-    [[location(4)]] border_radius: vec4<f32>;
+    @location(1) position: vec2<f32>;
+    @location(2) size: vec2<f32>;
+    @location(3) color: vec4<f32>;
+    @location(4) border_radius: vec4<f32>;
 };
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] src_position: vec2<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(0) src_position: vec2<f32>;
 
-    [[location(1)]] quad_size: vec2<f32>;
-    [[location(2)]] quad_color: vec4<f32>;
-    [[location(3)]] quad_border_radius: vec4<f32>;
+    @location(1) quad_size: vec2<f32>;
+    @location(2) quad_color: vec4<f32>;
+    @location(3) quad_border_radius: vec4<f32>;
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(vertex: Vertex, quad: QuadInstance) -> VertexOutput {
     var i_transform: mat4x4<f32> = mat4x4<f32>(
         vec4<f32>(quad.size.x, 0.0, 0.0, 0.0),
@@ -82,8 +81,8 @@ fn fragment_alpha(
 }
 
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) ->  [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) ->  @location(0) vec4<f32> {
     let alpha: f32 = fragment_alpha(
         in.src_position.xy,
         in.quad_size,


### PR DESCRIPTION
Now WGSL uses `@` for attributes instead of double brackets. cf. https://github.com/gpuweb/gpuweb/pull/2517

So I added support for that, and update test.wgsl to use new syntax.